### PR TITLE
[codex] Strengthen CI and fix root list filtering

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,11 @@
 Describe the changes in this pull request.
 
 ## Testing
-- [ ] `uvicorn app.main:app --reload`
-- [ ] Additional commands (please list)
+- [ ] `pytest`
+- [ ] `ruff check fieldflow fieldflow_mcp tests`
+- [ ] `black --check fieldflow fieldflow_mcp tests`
+- [ ] `mypy fieldflow fieldflow_mcp`
+- [ ] Additional commands or manual checks (please list)
 
 ## Checklist
 - [ ] Documentation updated (README, examples, etc.)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+      - python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,54 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  checks:
+  lint:
+    name: Lint and type check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev,mcp]'
+
+      - name: Ruff
+        run: ruff check fieldflow fieldflow_mcp tests
+
+      - name: Black
+        run: black --check fieldflow fieldflow_mcp tests
+
+      - name: Mypy
+        run: mypy fieldflow fieldflow_mcp
+
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -15,23 +56,58 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev,mcp]'
-
-      - name: Ruff
-        run: ruff check fieldflow fieldflow_mcp tests
-
-      - name: Mypy
-        run: mypy fieldflow fieldflow_mcp
+          python -m pip install -e '.[dev,mcp]'
 
       - name: Pytest
         run: pytest -q
+
+  package:
+    name: Build package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Install built wheel
+        run: python -m pip install dist/*.whl
+
+      - name: Smoke test imports
+        run: |
+          python -c "import fieldflow; print(fieldflow.__all__)"
+          fieldflow --help
+
+      - name: Check installed dependencies
+        run: python -m pip check
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: fieldflow-distributions
+          path: dist/*

--- a/fieldflow/cli.py
+++ b/fieldflow/cli.py
@@ -6,7 +6,6 @@ from typing import Optional
 import uvicorn
 
 
-
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="FieldFlow command line interface")
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/fieldflow/openapi_loader.py
+++ b/fieldflow/openapi_loader.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-
 try:
     import yaml  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover - yaml is optional

--- a/fieldflow/proxy.py
+++ b/fieldflow/proxy.py
@@ -100,10 +100,7 @@ class APIProxy:
                 f"Content preview: {preview}"
             )
             logger.error(error_detail)
-            raise HTTPException(
-                status_code=502,
-                detail=error_detail
-            ) from exc
+            raise HTTPException(status_code=502, detail=error_detail) from exc
         if selector_tree is None:
             return data
         return self._filter_fields(data, selector_tree)
@@ -187,7 +184,7 @@ def _tokenize_selector(selector: str) -> List[Token]:
         while idx < length:
             char = part[idx]
             if char == "[":
-                if part[idx: idx + 2] != "[]":
+                if part[idx : idx + 2] != "[]":
                     raise FieldSelectorError(
                         f"Only '[]' list selectors are supported ('{selector}')."
                     )
@@ -256,11 +253,12 @@ def apply_selector_tree(data: Any, node: FieldSelectorNode) -> Any:
     if isinstance(data, list):
         if node.include_self:
             return data
-        if node.all_items is None:
+        item_node = node.all_items if node.all_items is not None else node
+        if item_node is node and not node.keys:
             return _MISSING
         filtered_items: List[Any] = []
         for item in data:
-            filtered = apply_selector_tree(item, node.all_items)
+            filtered = apply_selector_tree(item, item_node)
             if filtered is _MISSING:
                 continue
             filtered_items.append(filtered)

--- a/fieldflow/spec_parser.py
+++ b/fieldflow/spec_parser.py
@@ -124,7 +124,9 @@ class SchemaFactory:
             return type(None)
         return self._maybe_optional(Any, nullable, force_optional)
 
-    def _maybe_optional(self, type_hint: Any, nullable: bool, force_optional: bool) -> Any:
+    def _maybe_optional(
+        self, type_hint: Any, nullable: bool, force_optional: bool
+    ) -> Any:
         if nullable or force_optional:
             from typing import Optional as TypingOptional
 

--- a/fieldflow_mcp/server.py
+++ b/fieldflow_mcp/server.py
@@ -7,7 +7,11 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
-from fieldflow.auth import AuthProvider, EnvironmentAuthProvider, OpenAPISecurityProvider
+from fieldflow.auth import (
+    AuthProvider,
+    EnvironmentAuthProvider,
+    OpenAPISecurityProvider,
+)
 from fieldflow.config import settings
 from fieldflow.openapi_loader import load_spec
 from fieldflow.proxy import APIProxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ mcp = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.black]
+target-version = ["py311", "py312"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["fieldflow*", "fieldflow_mcp*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "black>=24.3.0",
+  "black>=26.3.1,<27",
   "ruff>=0.4.0",
   "mypy>=1.10.0",
   "pytest>=7.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ mcp = [
   "mcp>=0.1.0",
 ]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["fieldflow*", "fieldflow_mcp*"]

--- a/tests/test_field_selector.py
+++ b/tests/test_field_selector.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from fieldflow import proxy as proxy_module
 from fieldflow.proxy import (
     APIProxy,
-    FieldSelectorError,
     apply_selector_tree,
     build_selector_tree,
 )
@@ -84,6 +84,19 @@ def test_root_list_selection() -> None:
     ]
 
 
+def test_root_list_selection_without_wildcard() -> None:
+    data = [
+        {"name": "Pikachu", "height": 4},
+        {"name": "Bulbasaur", "height": 7},
+    ]
+    tree = build_selector_tree(["name"])
+    filtered = apply_selector_tree(data, tree)
+    assert filtered == [
+        {"name": "Pikachu"},
+        {"name": "Bulbasaur"},
+    ]
+
+
 def test_missing_fields_return_empty_structure() -> None:
     data = {"name": "Pikachu"}
     tree = build_selector_tree(["height"])
@@ -92,8 +105,8 @@ def test_missing_fields_return_empty_structure() -> None:
 
 
 def test_invalid_selector_raises() -> None:
-    with pytest.raises(FieldSelectorError):
-        build_selector_tree(["moves[0].move"])
+    with pytest.raises(proxy_module.FieldSelectorError):
+        proxy_module.build_selector_tree(["moves[0].move"])
 
 
 def test_build_url_encodes_path_parameters() -> None:

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -72,8 +72,12 @@ def test_parser_resolves_request_body_and_response_refs() -> None:
             "/users": {
                 "post": {
                     "operationId": "createUser",
-                    "requestBody": {"$ref": "#/components/requestBodies/CreateUserBody"},
-                    "responses": {"201": {"$ref": "#/components/responses/UserResponse"}},
+                    "requestBody": {
+                        "$ref": "#/components/requestBodies/CreateUserBody"
+                    },
+                    "responses": {
+                        "201": {"$ref": "#/components/responses/UserResponse"}
+                    },
                 }
             }
         },


### PR DESCRIPTION
## What changed

- Reworked GitHub Actions CI into separate lint/type-check, test matrix, and package-build jobs.
- Added Black enforcement, package build/install smoke checks, `pip check`, artifact upload, dependency caching, workflow concurrency, manual dispatch, and read-only default permissions.
- Added Dependabot coverage for GitHub Actions and Python dependencies.
- Updated the PR template so local testing guidance matches this project.
- Fixed field selection for root-level list responses so selectors like `id` and `title` are applied to each item.
- Added regression coverage for root list filtering without an explicit `[]` wildcard.
- Scoped pytest collection to the tracked `tests/` directory so ignored local demo scripts do not run in the normal suite.
- Applied Black formatting to the existing source/test files that were already out of format.

## Why

The repo had only a minimal CI workflow, and the existing test suite also exposed a real list-filtering regression. This PR makes CI credible for an open-source repo by enforcing style, type checks, tests across supported Python versions, and package build health before the feature stack is marked ready.

## Validation

- `pytest`
- `ruff check fieldflow fieldflow_mcp tests`
- `.venv/bin/python -m black --check fieldflow fieldflow_mcp tests`
- `.venv/bin/python -m mypy fieldflow fieldflow_mcp`
- `.venv/bin/python -m pip check`
- `.venv/bin/python -m build`
- built wheel install smoke test with `fieldflow --help`
- `git diff --check`