### PR TITLE
[codex] Add smart field discovery

### DIFF
--- a/fieldflow/config.py
+++ b/fieldflow/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from .auth import AuthConfig, get_auth_config_from_env
+from .field_query import FieldDiscoveryConfig, FieldQueryAIConfig
 
 
 @dataclass(frozen=True)
@@ -15,6 +16,8 @@ class Settings:
     openapi_spec_path: Path
     target_api_base_url: Optional[str]
     auth_config: Optional[AuthConfig]
+    field_query_ai: FieldQueryAIConfig
+    field_discovery: FieldDiscoveryConfig
 
     @staticmethod
     def load() -> Settings:
@@ -30,11 +33,101 @@ class Settings:
 
         # Load authentication configuration
         auth_config = get_auth_config_from_env()
+        field_query_enabled = os.getenv(
+            "FIELD_FLOW_FIELD_QUERY_ENABLED", "false"
+        ).lower() not in {"0", "false", "no", "off"}
+        field_query_model = os.getenv("FIELD_FLOW_FIELD_QUERY_MODEL")
+        field_query_api_key = os.getenv("FIELD_FLOW_FIELD_QUERY_API_KEY") or os.getenv(
+            "OPENAI_API_KEY"
+        )
+        field_query_api_base_url = os.getenv(
+            "FIELD_FLOW_FIELD_QUERY_API_BASE_URL", "https://api.openai.com/v1"
+        )
+        timeout_raw = os.getenv("FIELD_FLOW_FIELD_QUERY_TIMEOUT_SECONDS", "8")
+        max_candidates_raw = os.getenv("FIELD_FLOW_FIELD_QUERY_MAX_CANDIDATES", "400")
+        preview_max_chars_raw = os.getenv(
+            "FIELD_FLOW_FIELD_QUERY_PREVIEW_MAX_CHARS", "12000"
+        )
+        discovery_enabled = os.getenv(
+            "FIELD_FLOW_DISCOVERY_ENABLED", "true"
+        ).lower() not in {"0", "false", "no", "off"}
+        discovery_ttl_raw = os.getenv("FIELD_FLOW_DISCOVERY_TTL_SECONDS", "180")
+        discovery_max_entries_raw = os.getenv("FIELD_FLOW_DISCOVERY_MAX_ENTRIES", "256")
+        discovery_max_candidates_raw = os.getenv(
+            "FIELD_FLOW_DISCOVERY_MAX_CANDIDATES", "400"
+        )
+        discovery_preview_max_chars_raw = os.getenv(
+            "FIELD_FLOW_DISCOVERY_PREVIEW_MAX_CHARS", "12000"
+        )
+        discovery_path_max_depth_raw = os.getenv(
+            "FIELD_FLOW_DISCOVERY_PATH_MAX_DEPTH", "8"
+        )
+        discovery_list_sample_size_raw = os.getenv(
+            "FIELD_FLOW_DISCOVERY_LIST_SAMPLE_SIZE", "10"
+        )
+
+        try:
+            timeout_seconds = float(timeout_raw)
+        except ValueError:
+            timeout_seconds = 8.0
+        try:
+            max_candidates = int(max_candidates_raw)
+        except ValueError:
+            max_candidates = 400
+        try:
+            preview_max_chars = int(preview_max_chars_raw)
+        except ValueError:
+            preview_max_chars = 12000
+        try:
+            discovery_ttl_seconds = int(discovery_ttl_raw)
+        except ValueError:
+            discovery_ttl_seconds = 180
+        try:
+            discovery_max_entries = int(discovery_max_entries_raw)
+        except ValueError:
+            discovery_max_entries = 256
+        try:
+            discovery_max_candidates = int(discovery_max_candidates_raw)
+        except ValueError:
+            discovery_max_candidates = 400
+        try:
+            discovery_preview_max_chars = int(discovery_preview_max_chars_raw)
+        except ValueError:
+            discovery_preview_max_chars = 12000
+        try:
+            discovery_path_max_depth = int(discovery_path_max_depth_raw)
+        except ValueError:
+            discovery_path_max_depth = 8
+        try:
+            discovery_list_sample_size = int(discovery_list_sample_size_raw)
+        except ValueError:
+            discovery_list_sample_size = 10
+
+        field_query_ai = FieldQueryAIConfig(
+            enabled=field_query_enabled,
+            model=field_query_model,
+            api_key=field_query_api_key,
+            api_base_url=field_query_api_base_url,
+            timeout_seconds=max(1.0, timeout_seconds),
+            max_candidates=max(10, max_candidates),
+            preview_max_chars=max(1000, preview_max_chars),
+        )
+        field_discovery = FieldDiscoveryConfig(
+            enabled=discovery_enabled,
+            ttl_seconds=max(5, discovery_ttl_seconds),
+            max_entries=max(10, discovery_max_entries),
+            max_candidates=max(10, discovery_max_candidates),
+            preview_max_chars=max(1000, discovery_preview_max_chars),
+            path_max_depth=max(1, discovery_path_max_depth),
+            list_sample_size=max(1, discovery_list_sample_size),
+        )
 
         return Settings(
             openapi_spec_path=path,
             target_api_base_url=base_url,
             auth_config=auth_config,
+            field_query_ai=field_query_ai,
+            field_discovery=field_discovery,
         )
 
 

--- a/fieldflow/field_query.py
+++ b/fieldflow/field_query.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FieldQueryAIConfig:
+    enabled: bool
+    model: Optional[str]
+    api_key: Optional[str]
+    api_base_url: str
+    timeout_seconds: float
+    max_candidates: int
+    preview_max_chars: int
+
+    def is_configured(self) -> bool:
+        return self.enabled and bool(self.model and self.api_key)
+
+
+@dataclass(frozen=True)
+class FieldDiscoveryConfig:
+    enabled: bool
+    ttl_seconds: int
+    max_entries: int
+    max_candidates: int
+    preview_max_chars: int
+    path_max_depth: int
+    list_sample_size: int
+
+
+class FieldQueryResolver(Protocol):
+    async def resolve(self, data: Any, query: str, *, max_fields: int) -> List[str]: ...
+
+    async def aclose(self) -> None: ...
+
+
+DISCOVERY_ERROR_NOT_FOUND = "not_found"
+DISCOVERY_ERROR_EXPIRED = "expired"
+DISCOVERY_ERROR_OPERATION_MISMATCH = "operation_mismatch"
+
+
+@dataclass
+class _DiscoveryEntry:
+    operation_name: str
+    data: Any
+    expires_at_epoch: float
+
+
+class FieldDiscoveryCache:
+    """Store discovery payloads so follow-up field selections can avoid a second API call."""
+
+    def __init__(self, config: FieldDiscoveryConfig):
+        self.config = config
+        self._entries: OrderedDict[str, _DiscoveryEntry] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def create(self, *, operation_name: str, data: Any) -> Dict[str, Any]:
+        all_candidates = extract_candidate_paths(
+            data,
+            max_depth=self.config.path_max_depth,
+            max_list_items=self.config.list_sample_size,
+        )
+        candidates = all_candidates[: self.config.max_candidates]
+        payload_preview = _build_payload_preview(
+            data, max_chars=self.config.preview_max_chars
+        )
+        now = time.time()
+        expires_at_epoch = now + self.config.ttl_seconds
+        discovery_id = secrets.token_urlsafe(12)
+        entry = _DiscoveryEntry(
+            operation_name=operation_name,
+            data=data,
+            expires_at_epoch=expires_at_epoch,
+        )
+
+        async with self._lock:
+            self._evict_expired_locked(now)
+            while len(self._entries) >= self.config.max_entries:
+                self._entries.popitem(last=False)
+            self._entries[discovery_id] = entry
+
+        return {
+            "discovery_id": discovery_id,
+            "operation_name": operation_name,
+            "expires_at": _format_utc_timestamp(expires_at_epoch),
+            "ttl_seconds": self.config.ttl_seconds,
+            "candidate_count": len(all_candidates),
+            "candidates": candidates,
+            "payload_preview": payload_preview,
+        }
+
+    async def load(
+        self,
+        discovery_id: str,
+        *,
+        operation_name: str,
+    ) -> Tuple[Optional[Any], Optional[str]]:
+        now = time.time()
+        key = discovery_id.strip()
+        if not key:
+            return None, DISCOVERY_ERROR_NOT_FOUND
+
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                self._evict_expired_locked(now)
+                return None, DISCOVERY_ERROR_NOT_FOUND
+            if entry.expires_at_epoch <= now:
+                del self._entries[key]
+                self._evict_expired_locked(now)
+                return None, DISCOVERY_ERROR_EXPIRED
+            if entry.operation_name != operation_name:
+                return None, DISCOVERY_ERROR_OPERATION_MISMATCH
+            self._entries.move_to_end(key)
+            return entry.data, None
+
+    async def aclose(self) -> None:
+        async with self._lock:
+            self._entries.clear()
+
+    def _evict_expired_locked(self, now: float) -> None:
+        expired_ids = [
+            discovery_id
+            for discovery_id, entry in self._entries.items()
+            if entry.expires_at_epoch <= now
+        ]
+        for discovery_id in expired_ids:
+            self._entries.pop(discovery_id, None)
+
+
+class AIFieldQueryResolver:
+    """Resolve natural-language field queries with a small LLM."""
+
+    def __init__(self, config: FieldQueryAIConfig):
+        self.config = config
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def resolve(self, data: Any, query: str, *, max_fields: int) -> List[str]:
+        if not self.config.is_configured():
+            return []
+        normalized_query = query.strip()
+        if not normalized_query:
+            return []
+
+        candidates = extract_candidate_paths(data)
+        if not candidates:
+            return []
+        candidate_list = candidates[: self.config.max_candidates]
+
+        payload_preview = _build_payload_preview(
+            data, max_chars=self.config.preview_max_chars
+        )
+        prompt = _build_user_prompt(
+            query=normalized_query,
+            candidates=candidate_list,
+            payload_preview=payload_preview,
+            max_fields=max_fields,
+        )
+        raw = await self._request_selection(prompt)
+        selected = _parse_selected_fields(raw)
+        if not selected:
+            return []
+        return _sanitize_selected_fields(
+            selected,
+            candidate_list,
+            max_fields=max_fields,
+        )
+
+    async def _request_selection(self, prompt: str) -> str:
+        client = self._get_client()
+        response = await client.post(
+            "/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.config.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": self.config.model,
+                "temperature": 0,
+                "response_format": {"type": "json_object"},
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You map user intent to existing JSON field selectors. "
+                            "Return ONLY valid JSON with shape "
+                            '{"selected_fields": ["field.path", "..."]}. '
+                            "Select only from provided candidates. "
+                            "Favor recall: include important supporting context when useful "
+                            "(identifiers, names, status). Do not invent fields."
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        choices = payload.get("choices", [])
+        if not choices:
+            return ""
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            chunks: List[str] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                text = item.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+            return "".join(chunks)
+        return ""
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.config.api_base_url.rstrip("/"),
+                timeout=self.config.timeout_seconds,
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        client = self._client
+        self._client = None
+        if client is None:
+            return
+        await client.aclose()
+
+
+def create_field_query_resolver(
+    config: FieldQueryAIConfig,
+) -> Optional[FieldQueryResolver]:
+    if not config.enabled:
+        return None
+    return AIFieldQueryResolver(config)
+
+
+def create_field_discovery_cache(
+    config: FieldDiscoveryConfig,
+) -> Optional[FieldDiscoveryCache]:
+    if not config.enabled:
+        return None
+    return FieldDiscoveryCache(config)
+
+
+def extract_candidate_paths(
+    data: Any, *, max_depth: int = 8, max_list_items: int = 10
+) -> List[str]:
+    result: set[str] = set()
+
+    def walk(value: Any, path: str, depth: int) -> None:
+        if depth > max_depth:
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                key_path = f"{path}.{key}" if path else key
+                result.add(key_path)
+                walk(child, key_path, depth + 1)
+            return
+        if isinstance(value, list):
+            list_path = f"{path}[]" if path else "[]"
+            result.add(list_path)
+            for child in value[:max_list_items]:
+                walk(child, list_path, depth + 1)
+
+    walk(data, "", 0)
+    return sorted(result)
+
+
+def _build_payload_preview(data: Any, *, max_chars: int) -> str:
+    preview_obj = _compact_value(data, depth=0, max_depth=4, max_list_items=3)
+    text = json.dumps(preview_obj, ensure_ascii=True, separators=(",", ":"))
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars]
+
+
+def _compact_value(
+    value: Any, *, depth: int, max_depth: int, max_list_items: int
+) -> Any:
+    if depth >= max_depth:
+        return _summarize_leaf(value)
+    if isinstance(value, dict):
+        compact: Dict[str, Any] = {}
+        for key, child in value.items():
+            compact[key] = _compact_value(
+                child,
+                depth=depth + 1,
+                max_depth=max_depth,
+                max_list_items=max_list_items,
+            )
+        return compact
+    if isinstance(value, list):
+        return [
+            _compact_value(
+                child,
+                depth=depth + 1,
+                max_depth=max_depth,
+                max_list_items=max_list_items,
+            )
+            for child in value[:max_list_items]
+        ]
+    return _summarize_leaf(value)
+
+
+def _summarize_leaf(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return {"type": "list", "length": len(value)}
+    if isinstance(value, dict):
+        return {"type": "object", "keys": list(value.keys())[:8]}
+    return str(type(value).__name__)
+
+
+def _build_user_prompt(
+    *,
+    query: str,
+    candidates: List[str],
+    payload_preview: str,
+    max_fields: int,
+) -> str:
+    candidate_lines = "\n".join(f"- {item}" for item in candidates)
+    return (
+        f"User field request:\n{query}\n\n"
+        f"Max fields to return: {max_fields}\n\n"
+        "Candidate selectors (must choose only from this list):\n"
+        f"{candidate_lines}\n\n"
+        "Payload preview:\n"
+        f"{payload_preview}\n\n"
+        "Return JSON only."
+    )
+
+
+def _parse_selected_fields(raw: str) -> List[str]:
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("field_query model output is not valid JSON")
+        return []
+    selected = payload.get("selected_fields")
+    if not isinstance(selected, list):
+        return []
+    return [item for item in selected if isinstance(item, str)]
+
+
+def _sanitize_selected_fields(
+    selected: List[str],
+    candidates: List[str],
+    *,
+    max_fields: int,
+) -> List[str]:
+    candidate_set = set(candidates)
+    unique: List[str] = []
+    for field in selected:
+        if field not in candidate_set:
+            continue
+        if field in unique:
+            continue
+        unique.append(field)
+        if len(unique) >= max_fields:
+            break
+    return unique
+
+
+def _format_utc_timestamp(epoch_seconds: float) -> str:
+    stamp = datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+    return stamp.replace("+00:00", "Z")

--- a/fieldflow/http_app.py
+++ b/fieldflow/http_app.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from .auth import AuthProvider, EnvironmentAuthProvider, OpenAPISecurityProvider
 from .config import settings
+from .field_query import create_field_discovery_cache, create_field_query_resolver
 from .openapi_loader import load_spec
 from .proxy import APIProxy
 from .spec_parser import OpenAPIParser
@@ -38,6 +39,8 @@ def create_fastapi_app() -> FastAPI:
         base_url,
         auth_provider=auth_provider,
         default_auth_config=settings.auth_config,
+        field_query_resolver=create_field_query_resolver(settings.field_query_ai),
+        field_discovery_cache=create_field_discovery_cache(settings.field_discovery),
     )
     app = FastAPI(
         title="FieldFlow API",

--- a/fieldflow/proxy.py
+++ b/fieldflow/proxy.py
@@ -9,6 +9,14 @@ import httpx
 from fastapi import HTTPException
 
 from .auth import AuthConfig, AuthProvider
+from .field_query import (
+    DISCOVERY_ERROR_EXPIRED,
+    DISCOVERY_ERROR_NOT_FOUND,
+    DISCOVERY_ERROR_OPERATION_MISMATCH,
+    FieldDiscoveryCache,
+    FieldQueryResolver,
+    extract_candidate_paths,
+)
 from .spec_parser import EndpointOperation
 
 logger = logging.getLogger(__name__)
@@ -22,10 +30,14 @@ class APIProxy:
         base_url: str,
         auth_provider: Optional[AuthProvider] = None,
         default_auth_config: Optional[AuthConfig] = None,
+        field_query_resolver: Optional[FieldQueryResolver] = None,
+        field_discovery_cache: Optional[FieldDiscoveryCache] = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.auth_provider = auth_provider
         self.default_auth_config = default_auth_config
+        self.field_query_resolver = field_query_resolver
+        self.field_discovery_cache = field_discovery_cache
         self._client: Optional[httpx.AsyncClient] = None
 
     async def execute(
@@ -35,8 +47,11 @@ class APIProxy:
         path_params: Dict[str, Any],
         query_params: Dict[str, Any],
         body: Optional[Dict[str, Any]],
-        fields: Optional[List[str]],
         path_template: str,
+        fields: Optional[List[str]] = None,
+        field_query: Optional[str] = None,
+        field_query_limit: int = 8,
+        discovery_id: Optional[str] = None,
     ) -> Any:
         selector_tree: Optional[FieldSelectorTree] = None
         if fields:
@@ -44,66 +59,58 @@ class APIProxy:
                 selector_tree = build_selector_tree(fields)
             except FieldSelectorError as exc:
                 raise HTTPException(status_code=422, detail=str(exc))
-
-        url = self._build_url(path_template, path_params)
-        method = operation.method.upper()
-        request_kwargs: Dict[str, Any] = {}
-        if query_params:
-            request_kwargs["params"] = query_params
-        if body is not None:
-            request_kwargs["json"] = body
-
-        # Add authentication headers if available
-        if self.auth_provider:
-            auth_headers = self.auth_provider.get_auth_headers(
-                operation, self.default_auth_config
-            )
-            if auth_headers:
-                request_kwargs["headers"] = auth_headers
-                # Log that we're authenticating without exposing credentials
-                sanitized = self.auth_provider.sanitize_headers(auth_headers)
-                logger.debug(f"Adding authentication headers: {sanitized}")
-
-        client = self._get_client()
-        response = await client.request(
-            method,
-            url,
-            **request_kwargs,
+        normalized_discovery_id = (
+            discovery_id.strip() if isinstance(discovery_id, str) else None
         )
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:  # pragma: no cover - error handling
-            # Sanitize any auth headers from error messages
-            detail = str(exc)
-            if self.auth_provider and request_kwargs.get("headers"):
-                for key, value in request_kwargs["headers"].items():
-                    if value in detail:
-                        detail = detail.replace(value, "[REDACTED]")
-            raise HTTPException(
-                status_code=exc.response.status_code, detail=detail
-            ) from exc
-        if not response.content:
-            return {}
-
-        # Parse JSON with explicit error handling
-        content_type = response.headers.get("content-type", "").lower()
-        try:
-            data = response.json()
-        except Exception as exc:
-            # Provide detailed error message when response is not JSON
-            preview = response.text[:200] if len(response.text) > 200 else response.text
-            error_detail = (
-                f"Upstream API returned non-JSON response. "
-                f"Status: {response.status_code}, "
-                f"Content-Type: {content_type or 'not set'}, "
-                f"URL: {url}, "
-                f"Content preview: {preview}"
+        if normalized_discovery_id:
+            data = await self._load_discovery_payload(
+                normalized_discovery_id,
+                operation_name=operation.name,
             )
-            logger.error(error_detail)
-            raise HTTPException(status_code=502, detail=error_detail) from exc
+        else:
+            data = await self._request_upstream_json(
+                operation=operation,
+                path_params=path_params,
+                query_params=query_params,
+                body=body,
+                path_template=path_template,
+            )
+        if selector_tree is None and field_query:
+            resolved_fields = await resolve_field_query(
+                data,
+                field_query,
+                max_fields=field_query_limit,
+                resolver=self.field_query_resolver,
+            )
+            if resolved_fields:
+                selector_tree = build_selector_tree(resolved_fields)
         if selector_tree is None:
             return data
         return self._filter_fields(data, selector_tree)
+
+    async def discover_fields(
+        self,
+        *,
+        operation: EndpointOperation,
+        path_params: Dict[str, Any],
+        query_params: Dict[str, Any],
+        body: Optional[Dict[str, Any]],
+        path_template: str,
+    ) -> Dict[str, Any]:
+        cache = self.field_discovery_cache
+        if cache is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Field discovery is disabled. Set FIELD_FLOW_DISCOVERY_ENABLED=true.",
+            )
+        data = await self._request_upstream_json(
+            operation=operation,
+            path_params=path_params,
+            query_params=query_params,
+            body=body,
+            path_template=path_template,
+        )
+        return await cache.create(operation_name=operation.name, data=data)
 
     def _build_url(self, template: str, path_params: Dict[str, Any]) -> str:
         url = template
@@ -127,17 +134,127 @@ class APIProxy:
             self._client = httpx.AsyncClient(base_url=self.base_url)
         return self._client
 
+    async def _request_upstream_json(
+        self,
+        *,
+        operation: EndpointOperation,
+        path_params: Dict[str, Any],
+        query_params: Dict[str, Any],
+        body: Optional[Dict[str, Any]],
+        path_template: str,
+    ) -> Any:
+        url = self._build_url(path_template, path_params)
+        method = operation.method.upper()
+        request_kwargs = self._build_request_kwargs(operation, query_params, body)
+        client = self._get_client()
+        response = await client.request(
+            method,
+            url,
+            **request_kwargs,
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - error handling
+            detail = str(exc)
+            headers = request_kwargs.get("headers")
+            if self.auth_provider and isinstance(headers, dict):
+                for _, value in headers.items():
+                    if isinstance(value, str) and value and value in detail:
+                        detail = detail.replace(value, "[REDACTED]")
+            raise HTTPException(
+                status_code=exc.response.status_code, detail=detail
+            ) from exc
+        if not response.content:
+            return {}
+
+        content_type = response.headers.get("content-type", "").lower()
+        try:
+            return response.json()
+        except Exception as exc:
+            preview = response.text[:200] if len(response.text) > 200 else response.text
+            error_detail = (
+                f"Upstream API returned non-JSON response. "
+                f"Status: {response.status_code}, "
+                f"Content-Type: {content_type or 'not set'}, "
+                f"URL: {url}, "
+                f"Content preview: {preview}"
+            )
+            logger.error(error_detail)
+            raise HTTPException(status_code=502, detail=error_detail) from exc
+
+    def _build_request_kwargs(
+        self,
+        operation: EndpointOperation,
+        query_params: Dict[str, Any],
+        body: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        request_kwargs: Dict[str, Any] = {}
+        if query_params:
+            request_kwargs["params"] = query_params
+        if body is not None:
+            request_kwargs["json"] = body
+
+        if self.auth_provider:
+            auth_headers = self.auth_provider.get_auth_headers(
+                operation, self.default_auth_config
+            )
+            if auth_headers:
+                request_kwargs["headers"] = auth_headers
+                sanitized = self.auth_provider.sanitize_headers(auth_headers)
+                logger.debug("Adding authentication headers: %s", sanitized)
+        return request_kwargs
+
+    async def _load_discovery_payload(
+        self,
+        discovery_id: str,
+        *,
+        operation_name: str,
+    ) -> Any:
+        cache = self.field_discovery_cache
+        if cache is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Field discovery is disabled. Set FIELD_FLOW_DISCOVERY_ENABLED=true.",
+            )
+        payload, error = await cache.load(discovery_id, operation_name=operation_name)
+        if error is None:
+            return payload
+        if error == DISCOVERY_ERROR_EXPIRED:
+            detail = (
+                "The provided discovery_id has expired. Run the discovery tool again "
+                "to refresh candidates."
+            )
+        elif error == DISCOVERY_ERROR_OPERATION_MISMATCH:
+            detail = (
+                "The provided discovery_id belongs to a different tool operation and "
+                "cannot be reused here."
+            )
+        elif error == DISCOVERY_ERROR_NOT_FOUND:
+            detail = (
+                "Unknown discovery_id. Run the discovery tool first, then retry with "
+                "the returned discovery_id."
+            )
+        else:  # pragma: no cover - safeguard
+            detail = "Invalid discovery_id."
+        raise HTTPException(status_code=422, detail=detail)
+
     async def aclose(self) -> None:
         client = self._client
         self._client = None
         if client is None:
-            return
-        close_method = getattr(client, "aclose", None)
-        if close_method is None:
-            return
-        result = close_method()
-        if hasattr(result, "__await__"):
-            await result
+            close_targets: List[Any] = []
+        else:
+            close_targets = [client]
+        close_targets.append(self.field_query_resolver)
+        close_targets.append(self.field_discovery_cache)
+
+        for target in close_targets:
+            close_method = getattr(target, "aclose", None)
+            if close_method is None:
+                continue
+            result = close_method()
+            if hasattr(result, "__await__"):
+                await result
 
 
 class FieldSelectorError(ValueError):
@@ -267,3 +384,33 @@ def apply_selector_tree(data: Any, node: FieldSelectorNode) -> Any:
     if node.include_self:
         return data
     return _MISSING
+
+
+async def resolve_field_query(
+    data: Any,
+    query: str,
+    *,
+    max_fields: int = 8,
+    resolver: Optional[FieldQueryResolver] = None,
+) -> List[str]:
+    if resolver is None:
+        return []
+    try:
+        selected = await resolver.resolve(data, query, max_fields=max_fields)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.warning("field_query resolver failed: %s", exc)
+        return []
+    if not selected:
+        return []
+
+    valid_candidates = set(extract_candidate_paths(data))
+    filtered: List[str] = []
+    for item in selected:
+        if item not in valid_candidates:
+            continue
+        if item in filtered:
+            continue
+        filtered.append(item)
+        if len(filtered) >= max_fields:
+            break
+    return filtered

--- a/fieldflow/tooling.py
+++ b/fieldflow/tooling.py
@@ -14,13 +14,15 @@ def create_tools_router(
     schema_factory: SchemaFactory,
     proxy: APIProxy,
 ) -> APIRouter:
-    """Create a FastAPI router that exposes MCP tools for each API endpoint."""
+    """Create a FastAPI router that exposes generated operation and discovery endpoints."""
 
     router = APIRouter()
     for operation in operations:
         request_model = build_request_model(operation, schema_factory)
+        discovery_model = build_discovery_request_model(operation, schema_factory)
         response_model = operation.response_model or Dict[str, Any]
         endpoint_path = f"/tools/{operation.name}"
+        discovery_endpoint_path = f"/tools/{operation.name}/discover-fields"
         summary = (
             operation.summary or f"{operation.method.upper()} {operation.path}".strip()
         )
@@ -31,38 +33,17 @@ def create_tools_router(
             __request_model=request_model,
         ) -> Any:  # type: ignore[misc]
             param_map = getattr(__request_model, "__mcp_param_map__")
-            path_params = extract_parameters(payload, param_map["path"])
-            query_params = extract_parameters(
-                payload, param_map["query"], exclude_none=True
+            path_params, query_params, body_payload = _extract_proxy_payload(
+                payload, param_map
             )
             fields_name = param_map["fields"]
             requested_fields = getattr(payload, fields_name)
-
-            body_field = param_map.get("body")
-            body_payload = None
-            if body_field:
-                body_obj = getattr(payload, body_field)
-                if body_obj is not None:
-                    if isinstance(body_obj, BaseModel):
-                        body_payload = body_obj.dict(exclude_none=True, by_alias=True)
-                    elif isinstance(body_obj, dict):
-                        body_payload = body_obj
-                    else:
-                        raise HTTPException(
-                            status_code=400, detail="Request body must be an object"
-                        )
-
-            path_template = __operation.path
-            missing = [
-                name
-                for name, attr in param_map["path"].items()
-                if getattr(payload, attr) is None
-            ]
-            if missing:
-                raise HTTPException(
-                    status_code=422,
-                    detail=f"Missing required path parameters: {missing}",
-                )
+            field_query_name = param_map["field_query"]
+            requested_field_query = getattr(payload, field_query_name)
+            field_query_limit_name = param_map["field_query_limit"]
+            field_query_limit = getattr(payload, field_query_limit_name)
+            discovery_id_name = param_map["discovery_id"]
+            discovery_id = getattr(payload, discovery_id_name)
 
             return await proxy.execute(
                 operation=__operation,
@@ -70,12 +51,31 @@ def create_tools_router(
                 query_params=query_params,
                 body=body_payload,
                 fields=requested_fields,
-                path_template=path_template,
+                field_query=requested_field_query,
+                field_query_limit=field_query_limit,
+                discovery_id=discovery_id,
+                path_template=__operation.path,
+            )
+
+        async def discover_endpoint(
+            payload: Any = Body(...),
+            __operation=operation,
+            __request_model=discovery_model,
+        ) -> Any:  # type: ignore[misc]
+            param_map = getattr(__request_model, "__mcp_param_map__")
+            path_params, query_params, body_payload = _extract_proxy_payload(
+                payload, param_map
+            )
+            return await proxy.discover_fields(
+                operation=__operation,
+                path_params=path_params,
+                query_params=query_params,
+                body=body_payload,
+                path_template=__operation.path,
             )
 
         request_model.model_rebuild()
         endpoint.__annotations__["payload"] = request_model
-
         router.post(
             endpoint_path,
             response_model=response_model,
@@ -84,11 +84,44 @@ def create_tools_router(
             name=operation.name,
         )(endpoint)
 
+        discovery_model.model_rebuild()
+        discover_endpoint.__annotations__["payload"] = discovery_model
+        router.post(
+            discovery_endpoint_path,
+            response_model=Dict[str, Any],
+            response_model_exclude_none=True,
+            summary=f"Discover fields for {summary}",
+            name=f"{operation.name}__discover_fields",
+        )(discover_endpoint)
+
     return router
 
 
 def build_request_model(
     operation: EndpointOperation, schema_factory: SchemaFactory
+) -> Type[BaseModel]:
+    return _build_operation_payload_model(
+        operation,
+        schema_factory,
+        include_response_controls=True,
+    )
+
+
+def build_discovery_request_model(
+    operation: EndpointOperation, schema_factory: SchemaFactory
+) -> Type[BaseModel]:
+    return _build_operation_payload_model(
+        operation,
+        schema_factory,
+        include_response_controls=False,
+    )
+
+
+def _build_operation_payload_model(
+    operation: EndpointOperation,
+    schema_factory: SchemaFactory,
+    *,
+    include_response_controls: bool,
 ) -> Type[BaseModel]:
     fields: Dict[str, Tuple[Any, Any]] = {}
     used_names: Set[str] = set()
@@ -128,19 +161,67 @@ def build_request_model(
             _field_value(default, description="JSON request body"),
         )
 
-    fields_field_name, _ = _sanitize_name("fields", used_names)
-    from typing import List as TypingList
-    from typing import Optional as TypingOptional
+    param_map: Dict[str, Any] = {
+        "path": path_map,
+        "query": query_map,
+        "body": body_field_name,
+    }
 
-    fields[fields_field_name] = (
-        TypingOptional[TypingList[str]],
-        Field(
-            default=None,
-            description="Subset of response properties to include in the result.",
-        ),
-    )
+    if include_response_controls:
+        fields_field_name, _ = _sanitize_name("fields", used_names)
+        field_query_name, _ = _sanitize_name("field_query", used_names)
+        field_query_limit_name, _ = _sanitize_name("field_query_limit", used_names)
+        discovery_id_name, _ = _sanitize_name("discovery_id", used_names)
+        from typing import List as TypingList
+        from typing import Optional as TypingOptional
 
-    model_name = f"{operation.name}_payload".replace("-", "_")
+        fields[fields_field_name] = (
+            TypingOptional[TypingList[str]],
+            Field(
+                default=None,
+                description="Subset of response properties to include in the result.",
+            ),
+        )
+        fields[field_query_name] = (
+            TypingOptional[str],
+            Field(
+                default=None,
+                description=(
+                    "Natural-language/fuzzy field query. Used only when `fields` is not provided."
+                ),
+            ),
+        )
+        fields[field_query_limit_name] = (
+            int,
+            Field(
+                default=8,
+                ge=1,
+                le=50,
+                description="Maximum number of fields selected from `field_query`.",
+            ),
+        )
+        fields[discovery_id_name] = (
+            TypingOptional[str],
+            Field(
+                default=None,
+                description=(
+                    "Cache key returned by the discovery endpoint. When provided, "
+                    "FieldFlow reuses cached payload data instead of calling the "
+                    "upstream API again."
+                ),
+            ),
+        )
+        param_map.update(
+            {
+                "fields": fields_field_name,
+                "field_query": field_query_name,
+                "field_query_limit": field_query_limit_name,
+                "discovery_id": discovery_id_name,
+            }
+        )
+
+    model_name_suffix = "payload" if include_response_controls else "discovery_payload"
+    model_name = f"{operation.name}_{model_name_suffix}".replace("-", "_")
     base_model = type(
         f"{model_name.title()}Base",
         (BaseModel,),
@@ -152,18 +233,45 @@ def build_request_model(
         __module__=__name__,
         **fields,
     )  # type: ignore[call-overload]
-    setattr(
-        request_model,
-        "__mcp_param_map__",
-        {
-            "path": path_map,
-            "query": query_map,
-            "body": body_field_name,
-            "fields": fields_field_name,
-        },
-    )
+    setattr(request_model, "__mcp_param_map__", param_map)
     request_model.model_rebuild()
     return request_model
+
+
+def _extract_proxy_payload(
+    payload: BaseModel,
+    param_map: Dict[str, Any],
+) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[Dict[str, Any]]]:
+    path_params = extract_parameters(payload, param_map["path"])
+    missing = [
+        name
+        for name, attr in param_map["path"].items()
+        if getattr(payload, attr) is None
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Missing required path parameters: {missing}",
+        )
+    query_params = extract_parameters(payload, param_map["query"], exclude_none=True)
+    body_payload = _extract_body_payload(payload, param_map.get("body"))
+    return path_params, query_params, body_payload
+
+
+def _extract_body_payload(
+    payload: BaseModel,
+    body_field_name: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not body_field_name:
+        return None
+    body_obj = getattr(payload, body_field_name)
+    if body_obj is None:
+        return None
+    if isinstance(body_obj, BaseModel):
+        return body_obj.model_dump(exclude_none=True, by_alias=True)
+    if isinstance(body_obj, dict):
+        return body_obj
+    raise HTTPException(status_code=400, detail="Request body must be an object")
 
 
 def _parameter_type_and_default(

--- a/fieldflow_mcp/server.py
+++ b/fieldflow_mcp/server.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Optional, cast
+from typing import Any, Dict, List, Optional, Type, cast
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
@@ -13,15 +13,24 @@ from fieldflow.auth import (
     OpenAPISecurityProvider,
 )
 from fieldflow.config import settings
+from fieldflow.field_query import (
+    create_field_discovery_cache,
+    create_field_query_resolver,
+)
 from fieldflow.openapi_loader import load_spec
 from fieldflow.proxy import APIProxy
 from fieldflow.spec_parser import EndpointOperation, OpenAPIParser, SchemaFactory
-from fieldflow.tooling import build_request_model, extract_parameters
+from fieldflow.tooling import (
+    build_discovery_request_model,
+    build_request_model,
+    extract_parameters,
+)
 from fieldflow.utils import extract_base_url
 
 INSTRUCTIONS = (
     "Tools in this server are generated dynamically from the supplied OpenAPI specification. "
-    "Provide the required parameters and include a `fields` list whenever you only need part of the response."
+    "Use `<tool>__discover_fields` to get candidate field selectors when you do not know exact field names. "
+    "Then call `<tool>` with `fields` and the returned `discovery_id` for a cached, filtered response."
 )
 
 
@@ -40,11 +49,8 @@ def create_mcp_server(
             "The upstream API base URL could not be determined. Provide FIELD_FLOW_TARGET_API_BASE_URL or define a server in the spec."
         )
 
-    # Set up authentication providers
     env_auth_provider = EnvironmentAuthProvider()
     auth_provider: AuthProvider = env_auth_provider
-
-    # If OpenAPI spec has security schemes, use OpenAPISecurityProvider
     if parser.security_schemes:
         auth_provider = OpenAPISecurityProvider(
             parser.security_schemes, env_auth_provider
@@ -54,6 +60,8 @@ def create_mcp_server(
         base_url,
         auth_provider=auth_provider,
         default_auth_config=settings.auth_config,
+        field_query_resolver=create_field_query_resolver(settings.field_query_ai),
+        field_discovery_cache=create_field_discovery_cache(settings.field_discovery),
     )
     server = FastMCP(
         name=name or "fieldflow-mcp",
@@ -73,10 +81,93 @@ def _register_operation(
     schema_factory: SchemaFactory,
 ) -> None:
     request_model = build_request_model(operation, schema_factory)
-    param_map = getattr(request_model, "__mcp_param_map__")
+    request_param_map = getattr(request_model, "__mcp_param_map__")
+    discovery_model = build_discovery_request_model(operation, schema_factory)
+    discovery_param_map = getattr(discovery_model, "__mcp_param_map__")
 
-    parameters = []
-    for field_name, field_info in request_model.model_fields.items():
+    return_annotation = operation.response_model or Any
+    structured_output = operation.response_model is not None
+
+    async def tool_fn(**kwargs: Any) -> Any:
+        payload = request_model(**kwargs)
+        path_params = extract_parameters(payload, request_param_map["path"])
+        query_params = extract_parameters(
+            payload, request_param_map["query"], exclude_none=True
+        )
+        fields_name = request_param_map["fields"]
+        requested_fields = getattr(payload, fields_name)
+        field_query_name = request_param_map["field_query"]
+        requested_field_query = getattr(payload, field_query_name)
+        field_query_limit_name = request_param_map["field_query_limit"]
+        field_query_limit = getattr(payload, field_query_limit_name)
+        discovery_id_name = request_param_map["discovery_id"]
+        discovery_id = getattr(payload, discovery_id_name)
+
+        body_payload = _extract_body_payload(payload, request_param_map.get("body"))
+        return await proxy.execute(
+            operation=operation,
+            path_params=path_params,
+            query_params=query_params,
+            body=body_payload,
+            fields=requested_fields,
+            field_query=requested_field_query,
+            field_query_limit=field_query_limit,
+            discovery_id=discovery_id,
+            path_template=operation.path,
+        )
+
+    async def discover_tool_fn(**kwargs: Any) -> Any:
+        payload = discovery_model(**kwargs)
+        path_params = extract_parameters(payload, discovery_param_map["path"])
+        query_params = extract_parameters(
+            payload, discovery_param_map["query"], exclude_none=True
+        )
+        body_payload = _extract_body_payload(payload, discovery_param_map.get("body"))
+        return await proxy.discover_fields(
+            operation=operation,
+            path_params=path_params,
+            query_params=query_params,
+            body=body_payload,
+            path_template=operation.path,
+        )
+
+    description = operation.summary or f"{operation.method.upper()} {operation.path}"
+    callable_tool = cast(Any, tool_fn)
+    callable_tool.__name__ = f"{operation.name}_tool"
+    callable_tool.__doc__ = description
+    callable_tool.__signature__ = inspect.Signature(
+        parameters=_build_signature_parameters(request_model),
+        return_annotation=return_annotation,
+    )
+    server.add_tool(
+        callable_tool,
+        name=operation.name,
+        title=description,
+        description=description,
+        structured_output=structured_output,
+    )
+
+    discover_name = f"{operation.name}__discover_fields"
+    discover_description = f"Discover candidate field selectors for {description}"
+    callable_discover_tool = cast(Any, discover_tool_fn)
+    callable_discover_tool.__name__ = f"{discover_name}_tool"
+    callable_discover_tool.__doc__ = discover_description
+    callable_discover_tool.__signature__ = inspect.Signature(
+        parameters=_build_signature_parameters(discovery_model),
+        return_annotation=Dict[str, Any],
+    )
+    server.add_tool(
+        callable_discover_tool,
+        name=discover_name,
+        title=discover_description,
+        description=discover_description,
+        structured_output=False,
+    )
+
+
+def _build_signature_parameters(model: Type[BaseModel]) -> List[inspect.Parameter]:
+    parameters: List[inspect.Parameter] = []
+    for field_name, field_info in model.model_fields.items():
         annotation = field_info.annotation or Any
         default = field_info.default
         if default is PydanticUndefined or field_info.is_required():
@@ -88,56 +179,23 @@ def _register_operation(
             annotation=annotation,
         )
         parameters.append(parameter)
+    return parameters
 
-    return_annotation = operation.response_model or Any
-    structured_output = operation.response_model is not None
 
-    async def tool_fn(**kwargs: Any) -> Any:
-        payload = request_model(**kwargs)
-
-        path_params = extract_parameters(payload, param_map["path"])
-        query_params = extract_parameters(
-            payload, param_map["query"], exclude_none=True
-        )
-        fields_name = param_map["fields"]
-        requested_fields = getattr(payload, fields_name)
-
-        body_field = param_map.get("body")
-        body_payload = None
-        if body_field:
-            body_obj = getattr(payload, body_field)
-            if body_obj is not None:
-                if isinstance(body_obj, BaseModel):
-                    body_payload = body_obj.model_dump(exclude_none=True, by_alias=True)
-                elif isinstance(body_obj, dict):
-                    body_payload = body_obj
-                else:
-                    raise ValueError("Request body must be an object")
-
-        return await proxy.execute(
-            operation=operation,
-            path_params=path_params,
-            query_params=query_params,
-            body=body_payload,
-            fields=requested_fields,
-            path_template=operation.path,
-        )
-
-    description = operation.summary or f"{operation.method.upper()} {operation.path}"
-    tool_fn.__name__ = f"{operation.name}_tool"
-    tool_fn.__doc__ = description
-    callable_tool = cast(Any, tool_fn)
-    callable_tool.__signature__ = inspect.Signature(
-        parameters=parameters, return_annotation=return_annotation
-    )
-
-    server.add_tool(
-        callable_tool,
-        name=operation.name,
-        title=description,
-        description=description,
-        structured_output=structured_output,
-    )
+def _extract_body_payload(
+    payload: BaseModel,
+    body_field_name: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not body_field_name:
+        return None
+    body_obj = getattr(payload, body_field_name)
+    if body_obj is None:
+        return None
+    if isinstance(body_obj, BaseModel):
+        return body_obj.model_dump(exclude_none=True, by_alias=True)
+    if isinstance(body_obj, dict):
+        return body_obj
+    raise ValueError("Request body must be an object")
 
 
 def run_stdio(name: Optional[str] = None, instructions: Optional[str] = None) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 import httpx
 from httpx import ASGITransport, AsyncClient as HTTPXAsyncClient
 import pytest
+import fieldflow.http_app as http_app_module
 from fieldflow import proxy as fieldflow_proxy
 from fieldflow.http_app import create_fastapi_app
 
@@ -41,6 +42,21 @@ class StubAsyncClient:
         return httpx.Response(200, request=request, json=payload)
 
 
+class StubFieldQueryResolver:
+    def __init__(self):
+        self.calls: List[Dict[str, Any]] = []
+
+    async def resolve(self, data: Any, query: str, *, max_fields: int) -> List[str]:
+        self.calls.append({"query": query, "max_fields": max_fields, "data": data})
+        normalized = query.lower()
+        if "mail" in normalized:
+            return ["email", "id", "unknown"]
+        return []
+
+    async def aclose(self) -> None:
+        return None
+
+
 @pytest.fixture(autouse=True)
 def _reset_stub_state():
     StubAsyncClient.queue = []
@@ -61,6 +77,23 @@ def app_instance(monkeypatch: pytest.MonkeyPatch, reload_app_modules):
 
     monkeypatch.setattr(fieldflow_proxy.httpx, "AsyncClient", StubAsyncClient)
     return create_fastapi_app()
+
+
+@pytest.fixture()
+def app_instance_with_field_query(monkeypatch: pytest.MonkeyPatch, reload_app_modules):
+    monkeypatch.setenv("FIELD_FLOW_OPENAPI_SPEC_PATH", str(EXAMPLE_SPEC))
+    monkeypatch.delenv("FIELD_FLOW_TARGET_API_BASE_URL", raising=False)
+
+    reload_app_modules()
+
+    resolver = StubFieldQueryResolver()
+    monkeypatch.setattr(fieldflow_proxy.httpx, "AsyncClient", StubAsyncClient)
+    monkeypatch.setattr(
+        http_app_module,
+        "create_field_query_resolver",
+        lambda config: resolver,
+    )
+    return create_fastapi_app(), resolver
 
 
 @pytest.mark.asyncio
@@ -141,3 +174,113 @@ async def test_proxy_reuses_http_client_between_requests(app_instance):
     assert response_one.status_code == 200
     assert response_two.status_code == 200
     assert StubAsyncClient.init_count == 1
+
+
+@pytest.mark.asyncio
+async def test_field_query_selects_ai_selected_fields(app_instance_with_field_query):
+    app_instance, resolver = app_instance_with_field_query
+    StubAsyncClient.queue.append(
+        {
+            "id": 1,
+            "name": "Leanne Graham",
+            "email": "Sincere@april.biz",
+            "username": "Bret",
+        }
+    )
+
+    async with HTTPXAsyncClient(
+        transport=ASGITransport(app=app_instance), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/tools/get_user_info",
+            json={"user_id": 1, "field_query": "mail"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["email"] == "Sincere@april.biz"
+    assert payload["id"] == 1
+    assert payload.keys() == {"email", "id"}
+    assert len(resolver.calls) == 1
+    assert resolver.calls[0]["query"] == "mail"
+
+
+@pytest.mark.asyncio
+async def test_field_query_returns_full_payload_when_resolver_returns_empty(
+    app_instance_with_field_query,
+):
+    app_instance, resolver = app_instance_with_field_query
+    StubAsyncClient.queue.append(
+        {
+            "id": 1,
+            "name": "Leanne Graham",
+            "email": "Sincere@april.biz",
+            "username": "Bret",
+        }
+    )
+
+    async with HTTPXAsyncClient(
+        transport=ASGITransport(app=app_instance), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/tools/get_user_info",
+            json={"user_id": 1, "field_query": "completely unknown thing"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "id" in payload
+    assert "name" in payload
+    assert len(resolver.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discovery_endpoint_returns_candidates_and_cached_lookup(app_instance):
+    StubAsyncClient.queue.append(
+        {
+            "id": 1,
+            "name": "Leanne Graham",
+            "email": "Sincere@april.biz",
+            "username": "Bret",
+        }
+    )
+
+    async with HTTPXAsyncClient(
+        transport=ASGITransport(app=app_instance), base_url="http://testserver"
+    ) as client:
+        discovery_response = await client.post(
+            "/tools/get_user_info/discover-fields",
+            json={"user_id": 1},
+        )
+        assert discovery_response.status_code == 200
+        discovery_payload = discovery_response.json()
+        assert "discovery_id" in discovery_payload
+        assert "email" in discovery_payload["candidates"]
+
+        response = await client.post(
+            "/tools/get_user_info",
+            json={
+                "user_id": 1,
+                "discovery_id": discovery_payload["discovery_id"],
+                "fields": ["email"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"email": "Sincere@april.biz"}
+    assert len(StubAsyncClient.calls) == 1
+    assert StubAsyncClient.calls[0]["url"] == "/users/1"
+
+
+@pytest.mark.asyncio
+async def test_discovery_id_unknown_returns_422(app_instance):
+    async with HTTPXAsyncClient(
+        transport=ASGITransport(app=app_instance), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/tools/get_user_info",
+            json={"user_id": 1, "discovery_id": "missing-id", "fields": ["email"]},
+        )
+
+    assert response.status_code == 422
+    assert "discovery_id" in response.json()["detail"]

--- a/tests/test_field_selector.py
+++ b/tests/test_field_selector.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 import pytest
 
 from fieldflow import proxy as proxy_module
+from fieldflow.field_query import (
+    DISCOVERY_ERROR_OPERATION_MISMATCH,
+    FieldDiscoveryCache,
+    FieldDiscoveryConfig,
+    extract_candidate_paths,
+)
 from fieldflow.proxy import (
     APIProxy,
     apply_selector_tree,
     build_selector_tree,
+    resolve_field_query,
 )
 
 
@@ -116,3 +123,100 @@ def test_build_url_encodes_path_parameters() -> None:
         {"user_id": "alice/bob", "repo": "hello world"},
     )
     assert url == "/users/alice%2Fbob/repos/hello%20world"
+
+
+def test_extract_candidate_paths_includes_nested_and_list_paths() -> None:
+    data = {
+        "id": 1,
+        "moves": [
+            {"move": {"name": "Thunder Punch", "url": "https://pokeapi.co/move/9/"}}
+        ],
+    }
+    candidates = extract_candidate_paths(data)
+    assert "id" in candidates
+    assert "moves" in candidates
+    assert "moves[]" in candidates
+    assert "moves[].move.name" in candidates
+
+
+class StubResolver:
+    def __init__(self, selected: list[str]):
+        self.selected = selected
+        self.calls: list[tuple[str, int]] = []
+
+    async def resolve(self, data, query: str, *, max_fields: int) -> list[str]:
+        self.calls.append((query, max_fields))
+        return self.selected
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_resolve_field_query_uses_resolver_and_filters_invalid_fields() -> None:
+    data = {"name": "Leanne Graham", "email": "Sincere@april.biz"}
+    resolver = StubResolver(["email", "unknown", "email"])
+    resolved = await resolve_field_query(
+        data,
+        "mail",
+        max_fields=5,
+        resolver=resolver,
+    )
+    assert resolved == ["email"]
+    assert resolver.calls == [("mail", 5)]
+
+
+@pytest.mark.asyncio
+async def test_resolve_field_query_without_resolver_returns_empty() -> None:
+    data = {"name": "Leanne Graham", "email": "Sincere@april.biz"}
+    resolved = await resolve_field_query(data, "mail", max_fields=5, resolver=None)
+    assert resolved == []
+
+
+@pytest.mark.asyncio
+async def test_field_discovery_cache_create_and_load_round_trip() -> None:
+    cache = FieldDiscoveryCache(
+        FieldDiscoveryConfig(
+            enabled=True,
+            ttl_seconds=120,
+            max_entries=16,
+            max_candidates=32,
+            preview_max_chars=2000,
+            path_max_depth=8,
+            list_sample_size=5,
+        )
+    )
+    data = {"id": 1, "name": "Leanne Graham", "email": "Sincere@april.biz"}
+    discovery = await cache.create(operation_name="get_user_info", data=data)
+    assert "discovery_id" in discovery
+    assert "email" in discovery["candidates"]
+
+    loaded, error = await cache.load(
+        discovery["discovery_id"], operation_name="get_user_info"
+    )
+    assert error is None
+    assert loaded == data
+
+
+@pytest.mark.asyncio
+async def test_field_discovery_cache_rejects_operation_mismatch() -> None:
+    cache = FieldDiscoveryCache(
+        FieldDiscoveryConfig(
+            enabled=True,
+            ttl_seconds=120,
+            max_entries=16,
+            max_candidates=32,
+            preview_max_chars=2000,
+            path_max_depth=8,
+            list_sample_size=5,
+        )
+    )
+    discovery = await cache.create(
+        operation_name="get_user_info",
+        data={"email": "a@b.com"},
+    )
+    loaded, error = await cache.load(
+        discovery["discovery_id"], operation_name="list_posts"
+    )
+    assert loaded is None
+    assert error == DISCOVERY_ERROR_OPERATION_MISMATCH

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -22,25 +22,56 @@ async def test_create_mcp_server_registers_tools(
     captured: dict[str, Any] = {}
 
     async def fake_execute(self, **kwargs: Any) -> Any:
-        captured["kwargs"] = kwargs
+        captured["execute_kwargs"] = kwargs
         return {"name": "Mock", "email": "mock@example.com"}
+
+    async def fake_discover_fields(self, **kwargs: Any) -> Any:
+        captured["discover_kwargs"] = kwargs
+        return {
+            "discovery_id": "disc_123",
+            "operation_name": "get_user_info",
+            "candidate_count": 2,
+            "candidates": ["id", "email"],
+            "payload_preview": '{"id":1,"email":"mock@example.com"}',
+            "ttl_seconds": 180,
+            "expires_at": "2026-02-23T00:00:00Z",
+        }
 
     reload_app_modules()
     monkeypatch.setattr(APIProxy, "execute", fake_execute, raising=False)
+    monkeypatch.setattr(
+        APIProxy, "discover_fields", fake_discover_fields, raising=False
+    )
     import fieldflow.proxy as proxy_module
 
     monkeypatch.setattr(proxy_module.APIProxy, "execute", fake_execute, raising=False)
+    monkeypatch.setattr(
+        proxy_module.APIProxy,
+        "discover_fields",
+        fake_discover_fields,
+        raising=False,
+    )
 
     server = mcp_server.create_mcp_server()
     tool_names = [tool.name for tool in server._tool_manager.list_tools()]
     assert "get_user_info" in tool_names
+    assert "get_user_info__discover_fields" in tool_names
 
     result = await server._tool_manager.call_tool(
         "get_user_info",
-        {"user_id": 1, "fields": ["name", "email"]},
+        {"user_id": 1, "fields": ["name", "email"], "discovery_id": "disc_123"},
+    )
+    discovery = await server._tool_manager.call_tool(
+        "get_user_info__discover_fields",
+        {"user_id": 1},
     )
 
     assert result == {"name": "Mock", "email": "mock@example.com"}
-    assert captured["kwargs"]["path_params"] == {"user_id": 1}
-    assert captured["kwargs"]["query_params"] == {}
-    assert captured["kwargs"]["fields"] == ["name", "email"]
+    assert captured["execute_kwargs"]["path_params"] == {"user_id": 1}
+    assert captured["execute_kwargs"]["query_params"] == {}
+    assert captured["execute_kwargs"]["fields"] == ["name", "email"]
+    assert captured["execute_kwargs"]["discovery_id"] == "disc_123"
+
+    assert discovery["discovery_id"] == "disc_123"
+    assert captured["discover_kwargs"]["path_params"] == {"user_id": 1}
+    assert captured["discover_kwargs"]["query_params"] == {}


### PR DESCRIPTION
## What changed

- Added a `FieldDiscoveryCache` that extracts response field candidates and stores payloads for short-lived reuse.
- Added generated HTTP discovery endpoints at `/tools/<operation>/discover-fields`.
- Added `discovery_id` support so follow-up filtered calls can reuse the cached payload instead of calling the upstream API again.
- Added optional OpenAI-compatible `field_query` resolution for natural-language field selection, disabled by default.
- Registered matching MCP discovery tools named `<tool>__discover_fields` and wired MCP calls through the same discovery/query path.
- Added HTTP, selector/cache, and MCP tests for discovery, cached lookup, operation mismatch, and `field_query` fallback behavior.

## Why

Agents often do not know exact response field selectors before seeing a payload. This adds a two-step discovery flow that lets the agent inspect candidate selectors from a real response, then make a filtered cached call using only validated selectors.

## Stack

This is stacked on #3 (`codex/field-selector-test-hygiene`) to keep the core feature diff focused.

## Validation

- `pytest`
- `ruff check fieldflow fieldflow_mcp tests`
- `.venv/bin/python -m black --check fieldflow fieldflow_mcp tests`
- `.venv/bin/python -m mypy fieldflow fieldflow_mcp`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add smart field discovery so tools can list candidate response fields and reuse a cached payload for filtered follow-ups. Also adds an optional natural‑language `field_query` (OpenAI‑compatible) to auto-select fields when exact selectors are unknown.

- **New Features**
  - New discovery endpoints at `/tools/<operation>/discover-fields` return candidate selectors, a payload preview, `candidate_count`, `ttl_seconds`, `expires_at`, `operation_name`, and a `discovery_id` for short‑lived reuse.
  - Tool calls now accept `discovery_id`, `field_query`, and `field_query_limit`. If `fields` is missing and `field_query` is set, fields are auto‑resolved; otherwise, the full payload is returned. Cached calls with `discovery_id` skip the upstream API.
  - Matching MCP tools named `<tool>__discover_fields` expose the same discovery flow; regular tools accept the same response‑control params.
  - Config via env: `FIELD_FLOW_DISCOVERY_ENABLED` (on by default), `FIELD_FLOW_DISCOVERY_TTL_SECONDS`, plus sizing knobs for candidates, preview size, path depth, list sampling, and cache size; `FIELD_FLOW_FIELD_QUERY_*` (disabled by default; supports `OPENAI_API_KEY` and custom `FIELD_FLOW_FIELD_QUERY_API_BASE_URL`/timeout).
  - Added tests for AI field selection, empty‑selection fallback to full payload, discovery endpoints, cache reuse, operation mismatch, and unknown `discovery_id`.

- **Migration**
  - No changes needed to keep current behavior.
  - To use discovery: call `/tools/<operation>/discover-fields`, then call `/tools/<operation>` with `discovery_id` and `fields`.
  - To enable natural‑language selection: set `FIELD_FLOW_FIELD_QUERY_ENABLED=true`, provide `FIELD_FLOW_FIELD_QUERY_MODEL`, and set `FIELD_FLOW_FIELD_QUERY_API_KEY` or `OPENAI_API_KEY`.

<sup>Written for commit f6dad62c99a3d87bec5dc8393f4d67f8c86b4f0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

