### PR TITLE
add fieldflow-cli reducer subcommand

### DIFF
--- a/.agents/skills/fieldflow-cli/SKILL.md
+++ b/.agents/skills/fieldflow-cli/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: fieldflow-cli
+description: Use FieldFlow to inspect and reduce noisy JSON CLI output before it reaches model context. Trigger for read-only external CLI tasks likely to return large structured output, especially logs, list, describe, get, read, query, search, metrics, or status commands from tools like gcloud, gh, kubectl, aws, or similar CLIs that can emit JSON. Prefer `fieldflow-cli inspect` first, then rerun with explicit `--field` selectors. Do not use for tiny local commands, text-only commands, or mutating commands unless explicitly asked.
+---
+
+# FieldFlow CLI
+
+Use this skill to keep large JSON CLI output out of model context.
+
+## Qualify The Command
+
+Use `fieldflow-cli` only when all of these are true:
+
+- The command is read-only.
+- The command is external or service-facing, not a tiny local shell command.
+- The command can emit JSON on stdout.
+- The expected output is likely large enough that raw output would pollute context.
+
+Do not use this skill for commands like `pwd`, `date`, `ls`, `git status`, `rg`, or any mutating command such as `deploy`, `apply`, `delete`, or `create`.
+
+## Inspect First
+
+Run `fieldflow-cli inspect` before choosing selectors unless you already have a manifest for the exact same wrapped command.
+
+```bash
+fieldflow-cli inspect --sample-items 100 -- <wrapped command>
+```
+
+The inspect step writes a compact field catalog under `.fieldflow/inspect/` and prints the manifest to stdout. Treat that manifest as the source of truth for valid selectors.
+
+The manifest is deterministic and intentionally small:
+
+- `path`
+- `types`
+
+It does not store raw command output.
+
+## Pick Minimal Fields
+
+Choose the smallest field set that answers the user’s question.
+
+Prefer fields like:
+
+- timestamps
+- severity or status
+- identifiers or names
+- URLs
+- concise message fields
+- latency, count, or state fields
+
+Avoid broad selectors such as `[]` or whole nested objects unless the task truly needs them.
+
+## Run The Reduced Command
+
+After choosing selectors, rerun the command through `fieldflow-cli`.
+
+```bash
+fieldflow-cli \
+  --field "[].timestamp" \
+  --field "[].severity" \
+  --field "[].jsonPayload.message" \
+  -- \
+  <wrapped command>
+```
+
+If the result is too narrow, broaden the selectors and rerun the reduced call. Do not fall back to raw output unless the user explicitly asks for it.
+
+## JSON Output Rules
+
+Prefer the CLI’s native JSON mode:
+
+- `gcloud`: `--format=json`
+- `kubectl`: `-o json`
+- `gh`: `--json ...`
+- `aws`: JSON is already standard, or use `--output json` when needed
+
+If the command cannot emit JSON, do not use this skill.
+
+## Gcloud Example
+
+For noisy Cloud Run request or error logs:
+
+```bash
+fieldflow-cli inspect --sample-items 100 -- \
+  gcloud logging read \
+    'resource.type="cloud_run_revision" AND resource.labels.service_name="program-api-service" AND severity>=ERROR' \
+    --project=train-3328b \
+    --freshness=24h \
+    --limit=2000 \
+    --format=json
+```
+
+Then reduce to the smallest useful fields, for example:
+
+```bash
+fieldflow-cli \
+  --field "[].timestamp" \
+  --field "[].severity" \
+  --field "[].httpRequest.requestMethod" \
+  --field "[].httpRequest.requestUrl" \
+  --field "[].httpRequest.status" \
+  --field "[].httpRequest.latency" \
+  -- \
+  gcloud logging read \
+    'resource.type="cloud_run_revision" AND resource.labels.service_name="program-api-service" AND severity>=ERROR' \
+    --project=train-3328b \
+    --freshness=24h \
+    --limit=2000 \
+    --format=json
+```

--- a/.agents/skills/fieldflow-cli/agents/openai.yaml
+++ b/.agents/skills/fieldflow-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FieldFlow CLI"
+  short_description: "Shape noisy JSON CLI output"
+  default_prompt: "Use $fieldflow-cli to inspect a noisy JSON CLI command, choose minimal selectors, and rerun it through fieldflow-cli."

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .pytest_cache/
 app/__pycache__/
 .venv/
+.fieldflow/
 .DS_Store
 fieldflow_mcp/__pycache__/
 fieldflow/__pycache__/

--- a/fieldflow/__init__.py
+++ b/fieldflow/__init__.py
@@ -1,8 +1,14 @@
 """FieldFlow core package."""
 
-from .http_app import create_fastapi_app
 from .openapi_loader import load_spec
 from .tooling import build_request_model
+
+
+def create_fastapi_app():
+    from .http_app import create_fastapi_app as _create_fastapi_app
+
+    return _create_fastapi_app()
+
 
 __all__ = [
     "build_request_model",

--- a/fieldflow/cli.py
+++ b/fieldflow/cli.py
@@ -1,9 +1,91 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from typing import Optional
 
 import uvicorn
+
+from .cli_runner import CLICommandError, inspect_json_command, run_json_command
+
+
+def _add_run_cli_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--field",
+        dest="fields",
+        action="append",
+        default=[],
+        help="Field selector to keep in the returned JSON payload. Repeat to keep multiple fields.",
+    )
+    parser.add_argument(
+        "--max-items",
+        type=int,
+        default=None,
+        help="Limit the number of items kept from a root JSON array before field filtering.",
+    )
+    parser.add_argument(
+        "wrapped_command",
+        nargs=argparse.REMAINDER,
+        help="Command to execute. Prefix with -- to separate FieldFlow options from the wrapped command.",
+    )
+
+
+def _execute_run_cli(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    wrapped_command = list(args.wrapped_command)
+    if wrapped_command and wrapped_command[0] == "--":
+        wrapped_command = wrapped_command[1:]
+    if not wrapped_command:
+        parser.error("a wrapped command is required after --")
+    try:
+        result = run_json_command(
+            command=wrapped_command,
+            fields=args.fields,
+            max_items=args.max_items,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    except CLICommandError as exc:
+        print(json.dumps(exc.payload, indent=2), file=sys.stderr)
+        raise SystemExit(exc.exit_code) from exc
+
+    print(json.dumps(result, indent=2))
+
+
+def _add_inspect_cli_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--sample-items",
+        type=int,
+        default=100,
+        help="Maximum number of root array items to sample while inferring selector paths.",
+    )
+    parser.add_argument(
+        "wrapped_command",
+        nargs=argparse.REMAINDER,
+        help="Command to inspect. Prefix with -- to separate FieldFlow options from the wrapped command.",
+    )
+
+
+def _execute_inspect_cli(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    wrapped_command = list(args.wrapped_command)
+    if wrapped_command and wrapped_command[0] == "--":
+        wrapped_command = wrapped_command[1:]
+    if not wrapped_command:
+        parser.error("a wrapped command is required after --")
+    try:
+        result = inspect_json_command(
+            command=wrapped_command,
+            sample_items=args.sample_items,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    except CLICommandError as exc:
+        print(json.dumps(exc.payload, indent=2), file=sys.stderr)
+        raise SystemExit(exc.exit_code) from exc
+
+    print(json.dumps(result, indent=2))
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -23,6 +105,28 @@ def _build_parser() -> argparse.ArgumentParser:
         "--reload", action="store_true", help="Enable autoreload (development only)"
     )
 
+    run_cli_parser = subparsers.add_parser(
+        "run-cli",
+        help="Run a JSON-emitting CLI command and print a reduced result",
+    )
+    _add_run_cli_arguments(run_cli_parser)
+
+    return parser
+
+
+def _build_run_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="FieldFlow CLI reducer for JSON-emitting commands"
+    )
+    _add_run_cli_arguments(parser)
+    return parser
+
+
+def _build_inspect_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="FieldFlow CLI inspector for JSON-emitting commands"
+    )
+    _add_inspect_cli_arguments(parser)
     return parser
 
 
@@ -36,7 +140,24 @@ def main(argv: Optional[list[str]] = None) -> None:
         )
         return
 
+    if args.command == "run-cli":
+        _execute_run_cli(parser, args)
+        return
+
     parser.error(f"Unknown command: {args.command}")
+
+
+def run_cli_main(argv: Optional[list[str]] = None) -> None:
+    argv_list = list(sys.argv[1:] if argv is None else argv)
+    if argv_list and argv_list[0] == "inspect":
+        parser = _build_inspect_cli_parser()
+        args = parser.parse_args(argv_list[1:])
+        _execute_inspect_cli(parser, args)
+        return
+
+    parser = _build_run_cli_parser()
+    args = parser.parse_args(argv_list)
+    _execute_run_cli(parser, args)
 
 
 if __name__ == "__main__":

--- a/fieldflow/cli_runner.py
+++ b/fieldflow/cli_runner.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Sequence
+
+from .proxy import FieldSelectorError, filter_data_fields
+
+
+class CLICommandError(RuntimeError):
+    """Raised when a wrapped CLI command cannot produce a usable JSON payload."""
+
+    def __init__(self, payload: dict[str, Any], exit_code: int):
+        super().__init__(payload.get("error", "CLI command failed"))
+        self.payload = payload
+        self.exit_code = exit_code
+
+
+def run_json_command(
+    *,
+    command: Sequence[str],
+    fields: Sequence[str] | None = None,
+    max_items: int | None = None,
+) -> dict[str, Any]:
+    if not command:
+        raise ValueError("A wrapped command is required.")
+    if max_items is not None and max_items < 1:
+        raise ValueError("--max-items must be greater than 0.")
+    command_list, data, stderr_preview = _load_json_command_output(command)
+
+    input_items = len(data) if isinstance(data, list) else None
+    reduced = _limit_items(data, max_items)
+    if fields:
+        try:
+            reduced = filter_data_fields(reduced, list(fields))
+        except FieldSelectorError as exc:
+            raise CLICommandError(
+                {
+                    "command": command_list,
+                    "exit_code": 2,
+                    "error": str(exc),
+                },
+                exit_code=2,
+            ) from exc
+
+    payload = {
+        "command": command_list,
+        "exit_code": 0,
+        "result": reduced,
+    }
+    if input_items is not None:
+        payload["input_items"] = input_items
+    if isinstance(reduced, list):
+        payload["returned_items"] = len(reduced)
+    if stderr_preview:
+        payload["stderr"] = stderr_preview
+    return payload
+
+
+def inspect_json_command(
+    *,
+    command: Sequence[str],
+    sample_items: int = 100,
+    manifest_dir: Path | None = None,
+) -> dict[str, Any]:
+    if not command:
+        raise ValueError("A wrapped command is required.")
+    if sample_items < 1:
+        raise ValueError("--sample-items must be greater than 0.")
+
+    command_list, data, stderr_preview = _load_json_command_output(command)
+    manifest = _build_manifest(command_list, data, sample_items)
+    target_dir = manifest_dir or Path(".fieldflow") / "inspect"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = target_dir / f"{manifest['command_hash']}.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    payload = dict(manifest)
+    payload["manifest_path"] = str(manifest_path)
+    if stderr_preview:
+        payload["stderr"] = stderr_preview
+    return payload
+
+
+def _load_json_command_output(
+    command: Sequence[str],
+) -> tuple[list[str], Any, str | None]:
+    command_list = list(command)
+    try:
+        completed = subprocess.run(
+            command_list,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise CLICommandError(
+            {
+                "command": command_list,
+                "error": f"Command not found: {command_list[0]}",
+            },
+            exit_code=127,
+        ) from exc
+
+    stderr_preview = _trim_text(completed.stderr)
+
+    if completed.returncode != 0:
+        payload: dict[str, Any] = {
+            "command": command_list,
+            "exit_code": completed.returncode,
+            "error": "Wrapped command exited with a non-zero status.",
+        }
+        if stderr_preview:
+            payload["stderr"] = stderr_preview
+        raise CLICommandError(payload, exit_code=completed.returncode)
+
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        payload = {
+            "command": command_list,
+            "exit_code": 2,
+            "error": "Wrapped command did not emit valid JSON on stdout.",
+        }
+        if stderr_preview:
+            payload["stderr"] = stderr_preview
+        raise CLICommandError(payload, exit_code=2) from exc
+
+    return command_list, data, stderr_preview
+
+
+def _build_manifest(command: list[str], data: Any, sample_items: int) -> dict[str, Any]:
+    root_type = _json_type_name(data)
+    manifest: dict[str, Any] = {
+        "manifest_version": 1,
+        "command": command,
+        "command_hash": _command_hash(command),
+        "root_type": root_type,
+        "paths": [],
+        "path_count": 0,
+    }
+
+    if isinstance(data, list):
+        sampled = data[:sample_items]
+        manifest["input_items"] = len(data)
+        manifest["sampled_items"] = len(sampled)
+        path_entries = _inspect_list_samples(sampled)
+    elif isinstance(data, dict):
+        manifest["sampled_items"] = 1
+        path_entries = _inspect_object_sample(data)
+    else:
+        manifest["sampled_items"] = 1
+        path_entries = [{"path": "", "types": [root_type]}]
+
+    manifest["paths"] = path_entries
+    manifest["path_count"] = len(path_entries)
+    return manifest
+
+
+def _inspect_list_samples(samples: list[Any]) -> list[dict[str, Any]]:
+    if not samples:
+        return []
+
+    path_types: dict[str, set[str]] = {}
+    for sample in samples:
+        seen = _collect_sample_paths(sample, prefix="[]")
+        for path, types in seen.items():
+            collected = path_types.setdefault(path, set())
+            collected.update(types)
+
+    entries = []
+    for path in sorted(path_types):
+        entries.append(
+            {
+                "path": path,
+                "types": sorted(path_types[path]),
+            }
+        )
+    return entries
+
+
+def _inspect_object_sample(sample: dict[str, Any]) -> list[dict[str, Any]]:
+    seen = _collect_sample_paths(sample)
+    entries = []
+    for path in sorted(seen):
+        entries.append(
+            {
+                "path": path,
+                "types": sorted(seen[path]),
+            }
+        )
+    return entries
+
+
+def _collect_sample_paths(value: Any, *, prefix: str = "") -> dict[str, set[str]]:
+    seen: dict[str, set[str]] = {}
+    _visit_value(value, prefix, seen)
+    return seen
+
+
+def _visit_value(value: Any, prefix: str, seen: dict[str, set[str]]) -> None:
+    if prefix:
+        seen.setdefault(prefix, set()).add(_json_type_name(value))
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_prefix = key if not prefix else f"{prefix}.{key}"
+            _visit_value(child, child_prefix, seen)
+        return
+
+    if isinstance(value, list):
+        child_prefix = "[]" if not prefix else f"{prefix}[]"
+        for child in value:
+            _visit_value(child, child_prefix, seen)
+
+
+def _command_hash(command: list[str]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(command, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+    return digest[:16]
+
+
+def _json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "list"
+    return "unknown"
+
+
+def _limit_items(data: Any, max_items: int | None) -> Any:
+    if max_items is None or not isinstance(data, list):
+        return data
+    return data[:max_items]
+
+
+def _trim_text(text: str, limit: int = 1000) -> str | None:
+    cleaned = text.strip()
+    if not cleaned:
+        return None
+    if len(cleaned) <= limit:
+        return cleaned
+    return f"{cleaned[:limit]}..."

--- a/fieldflow/proxy.py
+++ b/fieldflow/proxy.py
@@ -113,14 +113,7 @@ class APIProxy:
         return url
 
     def _filter_fields(self, data: Any, selector_tree: "FieldSelectorTree") -> Any:
-        filtered = apply_selector_tree(data, selector_tree)
-        if filtered is _MISSING:
-            if isinstance(data, dict):
-                return {}
-            if isinstance(data, list):
-                return []
-            return None
-        return filtered
+        return filter_with_selector_tree(data, selector_tree)
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
@@ -267,3 +260,19 @@ def apply_selector_tree(data: Any, node: FieldSelectorNode) -> Any:
     if node.include_self:
         return data
     return _MISSING
+
+
+def filter_with_selector_tree(data: Any, selector_tree: FieldSelectorTree) -> Any:
+    filtered = apply_selector_tree(data, selector_tree)
+    if filtered is _MISSING:
+        if isinstance(data, dict):
+            return {}
+        if isinstance(data, list):
+            return []
+        return None
+    return filtered
+
+
+def filter_data_fields(data: Any, fields: List[str]) -> Any:
+    selector_tree = build_selector_tree(fields)
+    return filter_with_selector_tree(data, selector_tree)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,5 +58,6 @@ include = ["fieldflow*", "fieldflow_mcp*"]
 
 [project.scripts]
 fieldflow = "fieldflow.cli:main"
+fieldflow-cli = "fieldflow.cli:run_cli_main"
 fieldflow-mcp = "fieldflow_mcp.cli:main"
 mcp-proxy = "fieldflow_mcp.cli:legacy_entrypoint"

--- a/scripts/demo_manifest_gh.sh
+++ b/scripts/demo_manifest_gh.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/demo_manifest_gh.sh [options]
+
+Run a repeatable GitHub CLI vs FieldFlow demo for issues and pull requests.
+
+Options:
+  --repo OWNER/REPO     GitHub repository to query (default: mnfst/manifest)
+  --state STATE         GitHub state filter for issues and PRs (default: open)
+  --limit N             Max issues / PRs to fetch per command (default: 50)
+  --output-dir DIR      Directory for saved demo artifacts (default: system temp dir)
+  -h, --help            Show this help text
+
+Requirements:
+  - gh on PATH and authenticated
+  - fieldflow-cli on PATH
+  - python on PATH with tiktoken installed
+
+This script compares full stdout payloads after minifying JSON on both sides.
+FieldFlow numbers therefore include its own small wrapper metadata:
+command, exit_code, result, input_items, returned_items.
+EOF
+}
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || fail "missing required command: $name"
+}
+
+REPO="mnfst/manifest"
+STATE="open"
+LIMIT="50"
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || fail "--repo requires a value"
+      REPO="$2"
+      shift 2
+      ;;
+    --state)
+      [[ $# -ge 2 ]] || fail "--state requires a value"
+      STATE="$2"
+      shift 2
+      ;;
+    --limit)
+      [[ $# -ge 2 ]] || fail "--limit requires a value"
+      LIMIT="$2"
+      shift 2
+      ;;
+    --output-dir)
+      [[ $# -ge 2 ]] || fail "--output-dir requires a value"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$LIMIT" =~ ^[1-9][0-9]*$ ]] || fail "--limit must be a positive integer"
+
+require_command gh
+require_command fieldflow-cli
+require_command python
+
+gh auth status >/dev/null 2>&1 || fail "gh is not authenticated; run 'gh auth login'"
+
+python - <<'PY' >/dev/null 2>&1 || fail "python package 'tiktoken' is required for token counts"
+import tiktoken
+PY
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  safe_repo="${REPO//\//-}"
+  OUTPUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fieldflow-demo-${safe_repo}-XXXXXX")"
+else
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+log "writing demo artifacts to $OUTPUT_DIR"
+
+issue_json_fields="number,title,state,labels,author,comments,updatedAt,url"
+pr_json_fields="number,title,state,labels,author,reviews,reviewDecision,updatedAt,url"
+
+issue_raw_cmd=(
+  gh issue list
+  --repo "$REPO"
+  --state "$STATE"
+  --limit "$LIMIT"
+  --json "$issue_json_fields"
+)
+
+pr_raw_cmd=(
+  gh pr list
+  --repo "$REPO"
+  --state "$STATE"
+  --limit "$LIMIT"
+  --json "$pr_json_fields"
+)
+
+cd "$OUTPUT_DIR"
+
+log "capturing raw issue payload"
+"${issue_raw_cmd[@]}" > issues.raw.json
+
+log "inspecting issue fields with FieldFlow"
+fieldflow-cli inspect --sample-items "$LIMIT" -- "${issue_raw_cmd[@]}" > issues.inspect.json
+
+log "capturing reduced issue payload"
+fieldflow-cli \
+  --field "[].number" \
+  --field "[].title" \
+  --field "[].state" \
+  --field "[].updatedAt" \
+  --field "[].url" \
+  --field "[].author.login" \
+  --field "[].labels[].name" \
+  --field "[].comments[].author.login" \
+  --field "[].comments[].createdAt" \
+  -- \
+  "${issue_raw_cmd[@]}" > issues.fieldflow.json
+
+log "capturing raw PR payload"
+"${pr_raw_cmd[@]}" > prs.raw.json
+
+log "inspecting PR fields with FieldFlow"
+fieldflow-cli inspect --sample-items "$LIMIT" -- "${pr_raw_cmd[@]}" > prs.inspect.json
+
+log "capturing reduced PR payload"
+fieldflow-cli \
+  --field "[].number" \
+  --field "[].title" \
+  --field "[].state" \
+  --field "[].updatedAt" \
+  --field "[].url" \
+  --field "[].author.login" \
+  --field "[].labels[].name" \
+  --field "[].reviewDecision" \
+  --field "[].reviews[].author.login" \
+  --field "[].reviews[].state" \
+  --field "[].reviews[].submittedAt" \
+  -- \
+  "${pr_raw_cmd[@]}" > prs.fieldflow.json
+
+cat > summary_prompt.txt <<'EOF'
+Summarize the current open work in the repository.
+
+Return:
+- 5 issue themes with representative issue numbers
+- PRs that appear to need review attention
+- the most recently active work
+- anything labeled high priority
+
+Use only the provided JSON.
+If comment or review bodies are not present, do not speculate about their content.
+EOF
+
+python - "$OUTPUT_DIR" "$REPO" "$STATE" "$LIMIT" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+import tiktoken
+
+output_dir = Path(sys.argv[1])
+repo = sys.argv[2]
+state = sys.argv[3]
+limit = int(sys.argv[4])
+
+enc = tiktoken.get_encoding("o200k_base")
+
+files = {
+    "issues.raw": output_dir / "issues.raw.json",
+    "issues.fieldflow": output_dir / "issues.fieldflow.json",
+    "prs.raw": output_dir / "prs.raw.json",
+    "prs.fieldflow": output_dir / "prs.fieldflow.json",
+}
+
+
+def minified_json(text: str) -> str:
+    return json.dumps(json.loads(text), separators=(",", ":"))
+
+
+def stats_for(path: Path) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    mini = minified_json(text)
+    if isinstance(data, list):
+        items = len(data)
+    else:
+        items = int(data.get("returned_items", 0))
+    return {
+        "items": items,
+        "bytes_minified": len(mini.encode("utf-8")),
+        "tokens_minified_o200k": len(enc.encode(mini)),
+    }
+
+
+stats = {name: stats_for(path) for name, path in files.items()}
+combined_raw_tokens = (
+    stats["issues.raw"]["tokens_minified_o200k"]
+    + stats["prs.raw"]["tokens_minified_o200k"]
+)
+combined_fieldflow_tokens = (
+    stats["issues.fieldflow"]["tokens_minified_o200k"]
+    + stats["prs.fieldflow"]["tokens_minified_o200k"]
+)
+reduction = 0.0
+if combined_raw_tokens:
+    reduction = 100 * (combined_raw_tokens - combined_fieldflow_tokens) / combined_raw_tokens
+
+issue_manifest = json.loads((output_dir / "issues.inspect.json").read_text(encoding="utf-8"))
+pr_manifest = json.loads((output_dir / "prs.inspect.json").read_text(encoding="utf-8"))
+
+comparison = {
+    "repo": repo,
+    "state": state,
+    "limit": limit,
+    "metric": "minified JSON token count using tiktoken o200k_base",
+    "note": "FieldFlow counts include its wrapper metadata as printed on stdout.",
+    "stats": stats,
+    "combined": {
+        "raw_tokens_minified_o200k": combined_raw_tokens,
+        "fieldflow_tokens_minified_o200k": combined_fieldflow_tokens,
+        "token_reduction_percent": round(reduction, 1),
+    },
+    "inspect_manifests": {
+        "issues": {
+            "path_count": issue_manifest["path_count"],
+            "manifest_path": issue_manifest["manifest_path"],
+        },
+        "prs": {
+            "path_count": pr_manifest["path_count"],
+            "manifest_path": pr_manifest["manifest_path"],
+        },
+    },
+}
+
+(output_dir / "comparison.json").write_text(
+    json.dumps(comparison, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+print()
+print(f"Demo artifacts: {output_dir}")
+print(f"Repo: {repo}")
+print(f"State: {state}")
+print(f"Limit: {limit}")
+print()
+print(f"{'dataset':18} {'items':>5} {'bytes':>10} {'tokens':>10}")
+for name in ("issues.raw", "issues.fieldflow", "prs.raw", "prs.fieldflow"):
+    entry = stats[name]
+    print(
+        f"{name:18} "
+        f"{entry['items']:>5} "
+        f"{entry['bytes_minified']:>10} "
+        f"{entry['tokens_minified_o200k']:>10}"
+    )
+print()
+print(f"combined raw tokens:       {combined_raw_tokens}")
+print(f"combined fieldflow tokens: {combined_fieldflow_tokens}")
+print(f"token reduction:           {reduction:.1f}%")
+print()
+print("Saved files:")
+for filename in (
+    "issues.raw.json",
+    "issues.inspect.json",
+    "issues.fieldflow.json",
+    "prs.raw.json",
+    "prs.inspect.json",
+    "prs.fieldflow.json",
+    "comparison.json",
+    "summary_prompt.txt",
+):
+    print(f"- {output_dir / filename}")
+PY

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from fieldflow.cli import main, run_cli_main
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_run_cli_filters_json_output_without_persisting_raw(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = [
+        {
+            "timestamp": "2026-04-16T09:00:00Z",
+            "severity": "ERROR",
+            "httpRequest": {"requestUrl": "https://api.example.com/programs"},
+            "jsonPayload": {"message": "Primary failure", "detail": "stack trace"},
+        },
+        {
+            "timestamp": "2026-04-16T09:01:00Z",
+            "severity": "INFO",
+            "httpRequest": {"requestUrl": "https://api.example.com/health"},
+            "jsonPayload": {"message": "ignored"},
+        },
+    ]
+    code = f"import json; data = {payload!r}; print(json.dumps(data))"
+
+    main(
+        [
+            "run-cli",
+            "--field",
+            "[].timestamp",
+            "--field",
+            "[].severity",
+            "--field",
+            "[].jsonPayload.message",
+            "--max-items",
+            "1",
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert result["input_items"] == 2
+    assert result["returned_items"] == 1
+    assert result["result"] == [
+        {
+            "timestamp": "2026-04-16T09:00:00Z",
+            "severity": "ERROR",
+            "jsonPayload": {"message": "Primary failure"},
+        }
+    ]
+    assert "raw_ref" not in result
+
+
+def test_run_cli_returns_compact_error_for_non_json_stdout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "run-cli",
+                "--",
+                sys.executable,
+                "-c",
+                "print('not json')",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    error = json.loads(captured.err)
+
+    assert error["error"] == "Wrapped command did not emit valid JSON on stdout."
+    assert "raw_ref" not in error
+
+
+def test_fieldflow_cli_entrypoint_runs_without_subcommand(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = (
+        "import json; print(json.dumps([{"
+        "'severity':'ERROR','jsonPayload':{'message':'boom'}},"
+        "{'severity':'INFO','jsonPayload':{'message':'ignore'}}]))"
+    )
+
+    run_cli_main(
+        [
+            "--field",
+            "[].severity",
+            "--field",
+            "[].jsonPayload.message",
+            "--max-items",
+            "1",
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert result["returned_items"] == 1
+    assert result["result"] == [
+        {"severity": "ERROR", "jsonPayload": {"message": "boom"}}
+    ]
+
+
+def test_fieldflow_cli_inspect_persists_manifest_in_dot_fieldflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    code = (
+        "import json; print(json.dumps([{"
+        "'timestamp':'2026-04-16T09:00:00Z',"
+        "'severity':'ERROR',"
+        "'httpRequest':{'status':500,'requestUrl':'https://example.com'},"
+        "'jsonPayload':{'message':'boom'}},"
+        "{'timestamp':'2026-04-16T09:01:00Z','severity':'INFO'}]))"
+    )
+
+    run_cli_main(
+        [
+            "inspect",
+            "--sample-items",
+            "2",
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    manifest = json.loads(captured.out)
+
+    assert manifest["root_type"] == "list"
+    assert manifest["input_items"] == 2
+    assert manifest["sampled_items"] == 2
+    assert manifest["manifest_path"].startswith(".fieldflow/inspect/")
+
+    manifest_path = tmp_path / manifest["manifest_path"]
+    assert manifest_path.exists()
+
+    stored_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert stored_manifest["command_hash"] == manifest["command_hash"]
+    assert {entry["path"]: entry for entry in stored_manifest["paths"]}[
+        "[].severity"
+    ] == {
+        "path": "[].severity",
+        "types": ["string"],
+    }
+    assert {entry["path"]: entry for entry in stored_manifest["paths"]}[
+        "[].httpRequest.status"
+    ] == {
+        "path": "[].httpRequest.status",
+        "types": ["integer"],
+    }
+
+
+def test_fieldflow_cli_can_import_from_another_workdir(tmp_path: Path) -> None:
+    script = """
+import sys
+from fieldflow.cli import run_cli_main
+
+run_cli_main([
+    "inspect",
+    "--sample-items",
+    "1",
+    "--",
+    sys.executable,
+    "-c",
+    "import json; print(json.dumps([{'severity':'ERROR'}]))",
+])
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    manifest = json.loads(completed.stdout)
+    assert manifest["manifest_path"].startswith(".fieldflow/inspect/")
+    assert (tmp_path / manifest["manifest_path"]).exists()


### PR DESCRIPTION
## Summary
- New `fieldflow-cli` entry point that wraps noisy JSON-producing CLIs (gh, gcloud, kubectl, etc.) so agents can preview shape via `inspect`, then rerun with explicit `--field` selectors to trim payloads before they hit model context.
- Shared filter path: factored `filter_with_selector_tree` / `filter_data_fields` out of `proxy.py` so the CLI and HTTP proxy use the same selector logic.
- Lazy-imported `http_app` in `fieldflow/__init__.py` so the CLI does not pull FastAPI on import.
- Ships the `.agents/skills/fieldflow-cli` Claude Code skill and a `scripts/demo_manifest_gh.sh` demo that measures token reduction with tiktoken o200k.

## Test plan
- [ ] `pytest tests/test_cli.py` passes
- [ ] `pip install -e .` then `fieldflow-cli inspect -- gh issue list --json number,title,state` returns a shape summary
- [ ] Rerunning with `--field number --field title` returns only those fields and reuses the disk cache under `.fieldflow/`
- [ ] `fieldflow serve-http --reload` still starts (lazy http_app import didn't regress)
- [ ] `ruff check fieldflow tests` and `black --check fieldflow tests` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fieldflow-cli` to inspect and reduce noisy JSON from CLIs like `gh`, `gcloud`, and `kubectl`, so only selected fields reach model context. Also unifies field selector filtering and avoids importing `fastapi` when using the CLI.

- **New Features**
  - New `fieldflow-cli` entry point with `inspect` (prints a small field manifest) and run mode (reduce via `--field` selectors, optional `--max-items`).
  - `inspect` writes a deterministic manifest to `.fieldflow/inspect/` without storing raw output.
  - Ships a `.agents/skills/fieldflow-cli` skill and a `scripts/demo_manifest_gh.sh` demo.

- **Refactors**
  - Extracted `filter_with_selector_tree` and `filter_data_fields` so the CLI and HTTP proxy share selector logic.
  - Lazy-imported `http_app` in `fieldflow/__init__.py` to avoid importing `fastapi` for CLI use.
  - Added `fieldflow-cli` console script in `pyproject.toml`; kept `fieldflow serve-http` behavior unchanged.

<sup>Written for commit f185cacde3ee21b55bf29a56f416e5c61295b0f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

